### PR TITLE
Add files via upload

### DIFF
--- a/popup.js
+++ b/popup.js
@@ -42,15 +42,11 @@
           /* One |accept-language| substring has the highest weight. */
           return acceptLanguageSubstringArrayHighestWeightedItems[0];
         }
-        else {
-          /* Multiple |accept-language| substrings have the highest weight. */
-          return 'mul';
-        }
+        /* Multiple |accept-language| substrings have the highest weight. */
+        return 'mul';
       }
-      else {
-        /* Zero |accept-language| substrings have a weight exceeding zero. */
-        return 'q=0';
-      }
+      /* Zero |accept-language| substrings have a weight exceeding zero. */
+      return 'q=0';
     }
     /* The |accept-language| string is invalid. */
     return '⚠\u{fe0f}';

--- a/popup.js
+++ b/popup.js
@@ -3,8 +3,62 @@
 
   let backgroundPage = chrome.extension.getBackgroundPage();
 
+  let validAcceptLanguageStringRegex = /^[a-z]{1,8}(?:-[a-z]{1,8})?(?:;q=(?:0(?:\.\d{0,3})?|1(?:\.0{0,3})?))?(?:, *[a-z]{1,8}(?:-[a-z]{1,8})?(?:;q=(?:0(?:\.\d{0,3})?|1(?:\.0{0,3})?))?)*$/i;
+
+  let assignWeights = (item, index, array) => {
+    item = item.split(';q=');
+    item[0] = item[0].trim();
+    if (item.length === 1) {
+      /* The default weight is 1: */
+      item.push(1);
+    }
+    else {
+      item[1] = parseFloat(item[1].trim());
+    }
+    array[index] = item;
+  }
+
+  let getHighestWeightedAcceptLanguage = (text) => {
+    if (validAcceptLanguageStringRegex.test(text)) {
+      let acceptLanguageString = text;
+      let acceptLanguageSubstringArray = acceptLanguageString.split(',');
+      acceptLanguageSubstringArray.forEach(assignWeights);
+      let acceptLanguageSubstringArrayHighestWeight = null;
+      let acceptLanguageSubstringArrayHighestWeightedItems = null;
+      while (acceptLanguageSubstringArray.length > 0) {
+        let acceptLanguageSubstringArrayItem = acceptLanguageSubstringArray.pop();
+        let acceptLanguageSubstringArrayItemWeight = acceptLanguageSubstringArrayItem[1];
+        if (acceptLanguageSubstringArrayItemWeight > acceptLanguageSubstringArrayHighestWeight || acceptLanguageSubstringArrayHighestWeight === null) {
+          acceptLanguageSubstringArrayHighestWeight = acceptLanguageSubstringArrayItemWeight;
+          acceptLanguageSubstringArrayHighestWeightedItems = [];
+          acceptLanguageSubstringArrayHighestWeightedItems.push(acceptLanguageSubstringArrayItem[0]);
+        }
+        else if (acceptLanguageSubstringArrayItemWeight >= acceptLanguageSubstringArrayHighestWeight) {
+          acceptLanguageSubstringArrayHighestWeightedItems.push(acceptLanguageSubstringArrayItem[0]);
+        }
+      }
+      if (acceptLanguageSubstringArrayHighestWeight > 0) {
+        if (acceptLanguageSubstringArrayHighestWeightedItems.length === 1) {
+          /* One |accept-language| substring has the highest weight. */
+          return acceptLanguageSubstringArrayHighestWeightedItems[0];
+        }
+        else {
+          /* Multiple |accept-language| substrings have the highest weight. */
+          return "mul";
+        }
+      }
+      else {
+        /* Zero |accept-language| substrings have a weight exceeding zero. */
+        return 'q=0';
+      }
+    }
+    /* The |accept-language| string is invalid. */
+    return '⚠';
+  }
+
   let updateBadge = (text) => {
-    let label = /[^-,]*/.exec(text.trim())[0].toLowerCase();
+    text = text.trim();
+    let label = getHighestWeightedAcceptLanguage(text);
     chrome.browserAction.setBadgeText( { text: label });
   }
 
@@ -13,7 +67,7 @@
   input.select();
 
   input.addEventListener('input', e => {
-    updateBadge(e.target.value)
+    updateBadge(e.target.value);
   });
 
   input.addEventListener('input', e => {

--- a/popup.js
+++ b/popup.js
@@ -53,7 +53,7 @@
       }
     }
     /* The |accept-language| string is invalid. */
-    return '⚠';
+    return '⚠\u{fe0f}';
   }
 
   let updateBadge = (text) => {

--- a/popup.js
+++ b/popup.js
@@ -19,6 +19,9 @@
   }
 
   let getHighestWeightedAcceptLanguage = (text) => {
+    if (text === "") {
+      return "";
+    }
     if (validAcceptLanguageStringRegex.test(text)) {
       let acceptLanguageString = text;
       let acceptLanguageSubstringArray = acceptLanguageString.split(',');

--- a/popup.js
+++ b/popup.js
@@ -44,7 +44,7 @@
         }
         else {
           /* Multiple |accept-language| substrings have the highest weight. */
-          return "mul";
+          return 'mul';
         }
       }
       else {

--- a/popup.js
+++ b/popup.js
@@ -33,7 +33,7 @@
           acceptLanguageSubstringArrayHighestWeightedItems = [];
           acceptLanguageSubstringArrayHighestWeightedItems.push(acceptLanguageSubstringArrayItem[0]);
         }
-        else if (acceptLanguageSubstringArrayItemWeight >= acceptLanguageSubstringArrayHighestWeight) {
+        else if (acceptLanguageSubstringArrayItemWeight === acceptLanguageSubstringArrayHighestWeight) {
           acceptLanguageSubstringArrayHighestWeightedItems.push(acceptLanguageSubstringArrayItem[0]);
         }
       }


### PR DESCRIPTION
Adds badge text-based feedback indicating invalid |accept-language| strings, a single |accept-language|  substring, multiple valid |accept-language| substrings, and all |accept-language| having |;q=0|.

Not sure if "q=0" is the best feedback. It could be "!language" or something along those lines.